### PR TITLE
Adiciona api do senado e refatora congresso para câmara

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,5 +1,6 @@
 # Link default da API
-.API_LINK <- "https://dadosabertos.camara.leg.br"
+.CAMARA_API_LINK <- "https://dadosabertos.camara.leg.br"
+.SENADO_API_LINK <- "http://legis.senado.leg.br/dadosabertos/materia/"
 
 # Mensagens de erro
 .ERRO_RETORNO_JSON <- "API did not return json"

--- a/R/deputados.R
+++ b/R/deputados.R
@@ -19,7 +19,7 @@ fetch_deputado <- function(id = NULL, nome = NULL, idLegislatura = NULL, siglaUf
   parametros <- as.list(environment(), all = TRUE)
 
   if(!length(.verifica_parametros_entrada(parametros))){
-    .congresso_api(.DEPUTADOS_PATH) %>%
+    .camara_api(.DEPUTADOS_PATH) %>%
       .assert_dataframe_completo(.COLNAMES_DEP_INFO) %>%
       .coerce_types(.COLNAMES_DEP_INFO)
   }

--- a/R/partidos.R
+++ b/R/partidos.R
@@ -29,7 +29,7 @@ fetch_partido <- function(id = NULL, sigla = NULL, dataInicio = NULL,
   parametros <- as.list(environment(), all=TRUE)
 
   if(!length(.verifica_parametros_entrada(parametros)))
-    .congresso_api(.PARTIDOS_PATH) %>%
+    .camara_api(.PARTIDOS_PATH) %>%
     .assert_dataframe_completo(.COLNAMES_PARTIDOS) %>%
     .coerce_types(.COLNAMES_PARTIDOS)
   else if(is.null(id))

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -41,7 +41,7 @@ fetch_proposicao <- function(id = NULL, siglaUfAutor = NULL, siglaTipo = NULL,
   parametros <- as.list(environment(), all=TRUE)
 
   if(!length(.verifica_parametros_entrada(parametros)))
-    .congresso_api(.PROPOSICOES_PATH) %>%
+    .camara_api(.PROPOSICOES_PATH) %>%
     .assert_dataframe_completo(.COLNAMES_PROPOSICAO) %>%
     .coerce_types(.COLNAMES_PROPOSICAO)
   else if(is.null(id))
@@ -70,7 +70,7 @@ fetch_votacoes <- function(id_prop){
     dplyr::mutate(path = paste0(.PROPOSICOES_PATH, "/", id, "/votacoes")) %>%
     dplyr::rowwise() %>%
     dplyr::do(
-      .congresso_api(.$path)
+      .camara_api(.$path)
     ) %>%
     dplyr::ungroup() %>%
     .assert_dataframe_completo(.COLNAMES_VOTACOES) %>%
@@ -95,7 +95,7 @@ fetch_relacionadas <- function(id_prop){
     dplyr::mutate(path = paste0(.PROPOSICOES_PATH, "/", id_prop, "/relacionadas")) %>%
     dplyr::group_by(id_prop, path) %>%
       dplyr::do(
-               .congresso_api(.$path)
+               .camara_api(.$path)
              ) %>%
       dplyr::ungroup() %>%
       dplyr::select(-path) %>%
@@ -121,7 +121,7 @@ fetch_tramitacao <- function(id_prop){
       dplyr::mutate(path = paste0(.PROPOSICOES_PATH, "/", id_prop, "/tramitacoes")) %>%
         dplyr::group_by(id_prop, path) %>%
         dplyr::do(
-                 .congresso_api(.$path)
+                 .camara_api(.$path)
                ) %>%
         dplyr::ungroup() %>%
         dplyr::select(-path) %>%
@@ -145,7 +145,7 @@ fetch_id_proposicao <- function(tipo, numero, ano){
   tibble::tibble(tipo, numero, ano) %>%
     dplyr::rowwise() %>%
     dplyr::do(
-      .congresso_api(.PROPOSICOES_PATH,
+      .camara_api(.PROPOSICOES_PATH,
                      list(siglaTipo = .$tipo, numero = .$numero, ano = .$ano,
                           ordem = "ASC", ordenarPor = "id", dataInicio = paste0(ano,"-01-01")))$id %>%
         .verifica_id(.WARNING_PROPOSICAO_ID) %>%
@@ -164,7 +164,7 @@ fetch_id_proposicao <- function(tipo, numero, ano){
 #'
 #' @export
 .fetch_tipos_proposicao <- function(){
-  .congresso_api(.TIPOS_PROPOSICOES_PATH)
+  .camara_api(.TIPOS_PROPOSICOES_PATH)
 }
 
 #' @title Fetches the type of the proposition from its id

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,12 +14,12 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
 .use_backoff_exponencial <- function(path = NULL, query=NULL, timeout = 0, tentativa = 0){
   final_timeout <- timeout*2.05
   Sys.sleep(final_timeout)
-  .get_from_api(path, query, final_timeout, tentativa)
+  .get_from_camara_api(path, query, final_timeout, tentativa)
 }
 
-.get_from_api <- function(path=NULL, query=NULL, timeout = 1, tentativa = 0){
+.get_from_camara_api <- function(path=NULL, query=NULL, timeout = 1, tentativa = 0){
   ua <- httr::user_agent(.RCONGRESSO_LINK)
-  api_url <- httr::modify_url(.API_LINK, path = path, query = query)
+  api_url <- httr::modify_url(.CAMARA_API_LINK, path = path, query = query)
 
   #print(api_url)
 
@@ -42,17 +42,17 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
 }
 
 .get_hrefs <- function(path=NULL, query=NULL) {
-  resp <- .get_from_api(path, query)
+  resp <- .get_from_camara_api(path, query)
   .get_json(resp)$links
 }
 
-#' Wraps an access to the congress API given a relative path and query arguments.
+#' Wraps an access to the camara API given a relative path and query arguments.
 #' @param path URL relative to the API base URL
 #' @param query Query parameters
 #' @export
-.congresso_api <- function(path=NULL, query=NULL, asList = FALSE){
+.camara_api <- function(path=NULL, query=NULL, asList = FALSE){
 
-  resp <- .get_from_api(path, query)
+  resp <- .get_from_camara_api(path, query)
   obtained_data <- .get_json(resp)$dados
 
   if(!is.data.frame(obtained_data) && !asList){
@@ -164,7 +164,7 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
       tibble::as.tibble() %>%
       dplyr::rowwise() %>%
       dplyr::do(
-        .congresso_api(API_path, ., asList)
+        .camara_api(API_path, ., asList)
       )
   }
 }
@@ -184,7 +184,7 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
     dplyr::mutate(path = paste0(API_path, "/", id)) %>%
     dplyr::rowwise() %>%
     dplyr::do(
-      .congresso_api(.$path, asList = asList)
+      .camara_api(.$path, asList = asList)
     ) %>%
     dplyr::ungroup()
 }
@@ -211,7 +211,7 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
       tibble::as.tibble() %>%
       dplyr::rowwise() %>%
       dplyr::do(
-        .congresso_api(API_path, .)
+        .camara_api(API_path, .)
       )
   } else {
     req_ultima_pagina <- query
@@ -223,13 +223,13 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
       tibble::as.tibble() %>%
       dplyr::rowwise() %>%
       dplyr::do(
-        .congresso_api(API_path, .)
+        .camara_api(API_path, .)
       ) %>%
       dplyr::bind_rows(req_ultima_pagina %>%
                          tibble::as.tibble() %>%
                          dplyr::rowwise() %>%
                          dplyr::do(
-                           .congresso_api(API_path, .)
+                           .camara_api(API_path, .)
                          ))
   }
 }

--- a/R/votacoes.R
+++ b/R/votacoes.R
@@ -14,7 +14,7 @@ fetch_votacao <- function(id_votacao = NULL){
     dplyr::mutate(path = paste0(.VOTACOES_PATH, "/", id_votacao)) %>%
     dplyr::rowwise() %>%
     dplyr::do(
-      .congresso_api(.$path)
+      .camara_api(.$path)
     ) %>%
     dplyr::select(-which(grepl("orientacoes", names(.)))) %>%
     .assert_dataframe_completo(.COLNAMES_VOTACAO) %>%
@@ -37,7 +37,7 @@ fetch_orientacoes <- function(id_votacao = NULL){
     dplyr::mutate(path = paste0(.VOTACOES_PATH, "/", id_votacao)) %>%
     dplyr::group_by(id_votacao) %>%
     dplyr::do(
-      .congresso_api(.$path, asList = TRUE)$orientacoes
+      .camara_api(.$path, asList = TRUE)$orientacoes
     ) %>%
     dplyr::ungroup() %>%
     .assert_dataframe_completo(.COLNAMES_ORIENTACOES) %>%
@@ -70,7 +70,7 @@ fetch_votos <- function(id_votacao = NULL){
   queries %>%
     dplyr::group_by(id_votacao, path, query) %>%
     dplyr::do(
-      .congresso_api(.$path, .$query)
+      .camara_api(.$path, .$query)
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(-path, -query) %>%
@@ -138,7 +138,7 @@ fetch_proposicao_from_votacao <- function(id_votacao = NULL) {
     dplyr::mutate(path = paste0(.VOTACOES_PATH, "/", id_votacao)) %>%
     dplyr::group_by(id_votacao) %>%
     dplyr::do(
-      .congresso_api(.$path, asList = TRUE)$proposicao %>%
+      .camara_api(.$path, asList = TRUE)$proposicao %>%
         .get_dataframe()
     ) %>%
     dplyr::ungroup() %>%


### PR DESCRIPTION
As constantes estavam declaradas como congresso sendo que era referente a câmara, refatorei e adicionei nas funções o nome câmara para facilitar na separação com o senado.

E adiciona api do senado nas constantes