### PR TITLE
Adicionada 6ª página de votos

### DIFF
--- a/R/rcongresso.R
+++ b/R/rcongresso.R
@@ -8,3 +8,4 @@
 #' @name rcongresso
 #' @references \url{https://dadosabertos.camara.leg.br/swagger/api.html}
 NULL
+

--- a/R/rcongresso.R
+++ b/R/rcongresso.R
@@ -8,4 +8,3 @@
 #' @name rcongresso
 #' @references \url{https://dadosabertos.camara.leg.br/swagger/api.html}
 NULL
-

--- a/R/votacoes.R
+++ b/R/votacoes.R
@@ -63,7 +63,7 @@ fetch_votos <- function(id_votacao = NULL){
     dplyr::do(
       tibble::tibble(id_votacao = .$id_votacao,
               path = .$path,
-              query = paste0("pagina=", 1:5, "&itens=100"))
+              query = paste0("pagina=", 1:6, "&itens=100"))
     ) %>%
     dplyr::ungroup()
 


### PR DESCRIPTION
Conserta a issue #.

Mudanças propostas nesse PR:
- A função fetch_votos() faz requisições às 5 primeiras páginas da consulta de informações de votos por votação. Percebi que havia uma 6ª página com votos dos parlamentares que não eram contabilizadas, então modifiquei o código para acessar também esta última.
-
-

@paul0vinicius
